### PR TITLE
Track existing downloads by recording ID rather than meeting ID

### DIFF
--- a/zoom-recording-downloader.py
+++ b/zoom-recording-downloader.py
@@ -104,8 +104,8 @@ def format_filename(recording, file_type, file_extension, recording_type, record
     topic = recording['topic'].replace('/', '&')
     rec_type = recording_type.replace("_", " ").title()
     meeting_time = parse(recording['start_time'])
-    return '{} - {} UTC - {} - {}.{}'.format(
-        meeting_time.strftime('%Y.%m.%d'), meeting_time.strftime('%I.%M %p'), topic+" - "+rec_type, recording_id, file_extension.lower())
+    return '{} - {} UTC - {}{}.{}'.format(
+        meeting_time.strftime('%Y.%m.%d'), meeting_time.strftime('%I.%M %p'), topic+"/"+rec_type, recording_id, file_extension.lower())
 
 
 def get_downloads(recording):
@@ -161,7 +161,7 @@ def list_recordings(email):
 def download_recording(download_url, email, filename):
     dl_dir = os.sep.join([DOWNLOAD_DIRECTORY, email])
     full_filename = os.sep.join([dl_dir, filename])
-    os.makedirs(dl_dir, exist_ok=True)
+    os.makedirs(os.path.dirname(full_filename), exist_ok=True)
     response = requests.get(download_url, stream=True)
 
     # total size in bytes.
@@ -257,6 +257,9 @@ def main():
 
             downloads = get_downloads(recording)
             for file_type, file_extension, download_url, recording_type, recording_id, status in downloads:
+
+                #print(file_type, file_extension, download_url, recording_type, recording_id, status)
+
                 if recording_type != 'incomplete' and status == 'completed':
                     filename = format_filename(
                         recording, file_type, file_extension, recording_type, recording_id)

--- a/zoom-recording-downloader.py
+++ b/zoom-recording-downloader.py
@@ -123,7 +123,10 @@ def get_downloads(recording):
             recording_type = download['file_type']
         # must append JWT token to download_url
         download_url = download['download_url'] + "?access_token=" + JWT_TOKEN
-        downloads.append((file_type, file_extension, download_url, recording_type, recording_id))
+
+        status = download['status']
+
+        downloads.append((file_type, file_extension, download_url, recording_type, recording_id, status))
     return downloads
 
 
@@ -254,8 +257,8 @@ def main():
             #     continue
 
             downloads = get_downloads(recording)
-            for file_type, file_extension, download_url, recording_type, recording_id in downloads:
-                if recording_type != 'incomplete':
+            for file_type, file_extension, download_url, recording_type, recording_id, status in downloads:
+                if recording_type != 'incomplete' and status == 'completed':
                     filename = format_filename(
                         recording, file_type, file_extension, recording_type, recording_id)
 

--- a/zoom-recording-downloader.py
+++ b/zoom-recording-downloader.py
@@ -184,7 +184,7 @@ def download_recording(download_url, email, filename):
         return False
 
 
-def load_completed_meeting_ids():
+def load_completed_recording_ids():
     try:
         with open(COMPLETED_RECORDING_IDS_LOG, 'r') as fd:
             for line in fd:
@@ -233,7 +233,7 @@ def main():
                                   Version {}
 '''.format(APP_VERSION))
 
-    load_completed_meeting_ids()
+    load_completed_recording_ids()
 
     print(color.BOLD + "Getting user accounts..." + color.END)
     users = get_user_ids()
@@ -248,7 +248,6 @@ def main():
         print("==> Found {} recordings".format(total_count))
 
         for index, recording in enumerate(recordings):
-            success = False
             meeting_id = recording['uuid']
             # if meeting_id in COMPLETED_RECORDING_IDS:
             #     print("==> Skipping already downloaded meeting: {}".format(meeting_id))
@@ -260,23 +259,15 @@ def main():
                     filename = format_filename(
                         recording, file_type, file_extension, recording_type, recording_id)
 
-                    dl_dir = os.sep.join([DOWNLOAD_DIRECTORY, email])
-                    full_filename = os.sep.join([dl_dir, filename])
-
                     if recording_id in COMPLETED_RECORDING_IDS:
                         print("==> Skipping already downloaded recording: {}".format(recording_id))
                         continue
-
-
-                    # if os.path.isfile(full_filename):
-                    #     print("==> Skipping already downloaded file: {}".format(full_filename))
-                    #     continue
-
+                    
                     # truncate URL to 64 characters
                     truncated_url = download_url[0:64] + "..."
                     print("==> Downloading ({} of {}) as {}: {}: {}".format(
                         index+1, total_count, recording_type, recording_id, truncated_url))
-                    success |= download_recording(download_url, email, filename)
+                    success = download_recording(download_url, email, filename)
 
                     if success:
                         with open(COMPLETED_RECORDING_IDS_LOG, 'a') as log:
@@ -290,7 +281,6 @@ def main():
                     #success = True
                 else:
                     print("### Incomplete Recording ({} of {}) for {}".format(index+1, total_count, recording_id))
-                    success = False         
 
 
     print(color.BOLD + color.GREEN + "\n*** All done! ***" + color.END)

--- a/zoom-recording-downloader.py
+++ b/zoom-recording-downloader.py
@@ -114,6 +114,8 @@ def get_downloads(recording):
         file_type = download['file_type']
         file_extension = download['file_extension']
         recording_id = download['id']
+        status = download['status']
+
         if file_type == "":
             recording_type = 'incomplete'
             #print("\download is: {}".format(download))
@@ -123,9 +125,6 @@ def get_downloads(recording):
             recording_type = download['file_type']
         # must append JWT token to download_url
         download_url = download['download_url'] + "?access_token=" + JWT_TOKEN
-
-        status = download['status']
-
         downloads.append((file_type, file_extension, download_url, recording_type, recording_id, status))
     return downloads
 


### PR DESCRIPTION
This pull requests solves an issue where if new files get added to a meeting (e.x. a transcript) after the last download, it will skip it.
It tracks the files downloaded by the recording ID rather than the meeting ID. It will skip existing recording IDs, and download new ones. It follows the logic very similar to COMPLETED_MEETING_IDS

It also saves the file initially as a .tmp file when downloading and then renames it to the final filename after it successfully downloads. This guarantees the file is completely downloaded before being named recording.mp4
